### PR TITLE
Fix ast error in Foundry 0.2.0

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -569,13 +569,15 @@ function getArtifactDependencies(parsedArtifact) {
 }
 
 function getArtifactDependencies(parsedArtifact, contractName) {
-    var dependencies = {}
-    Object.entries(parsedArtifact.ast.exportedSymbols)
-        .forEach(symbol => {
-            if (symbol[0] != contractName) {
-                dependencies[symbol[0]] = null;
-            }
-        });
+    var dependencies = {};
+    if (parsedArtifact.ast && parsedArtifact.ast.exportedSymbols) {
+        Object.entries(parsedArtifact.ast.exportedSymbols)
+            .forEach(symbol => {
+                if (symbol[0] != contractName) {
+                    dependencies[symbol[0]] = null;
+                }
+            });
+    }
     return dependencies;
 }
 


### PR DESCRIPTION
This CLI tool worked fine with previous versions of Foundry, but since updating to 0.2.0 it is breaking with this error.

Error on line 574:
TypeError: Cannot read properties of undefined (reading 'exportedSymbols')

I'm not sure what caused the error so this is a quick fix to add a check so that the CLI tool now works with both the old and new versions of Foundry. I'm sure there is a better fix for this, but if anyone wants to get this tool working again after upgrading Foundry, this worked for me.